### PR TITLE
Add ignore files used for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
+# Terraform 
 .terraform
 *.tfstate*
-terraform-provider-spinnaker
-*.tf
 *.log
+
+# Binary 
+terraform-provider-spinnaker
+
+# For debugging
+*.tf
 pipelines
-vendor/*
+
+# Spin config
+config


### PR DESCRIPTION
## WHAT

As title. I added

* comments in the `.gitignore`
* add files(e.g. binary of the provider, config file for spinnaker/spin) that is used for development to `gitignore`

## WHY

Better local environment.
