### PR TITLE
fix(goreleaser): freebsd from artifact targets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,6 @@ builds:
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
-    - freebsd
     - windows
     - linux
     - darwin


### PR DESCRIPTION
## WHAT

As title.

## WHY

Spin doesn't support freebsd builds so we will remove it as well.
