### PR TITLE
Fix release tag for GitHub Actions

### DIFF
--- a/.github/workflows/release-provider.yml
+++ b/.github/workflows/release-provider.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-?[a-zA-z]*"
 
 jobs:
   test:


### PR DESCRIPTION
## What

Fixed the tag condition to  support `x.y.z-AAAA` 
