### PR TITLE
Removed "Planned" in v0.2.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug fixes
 * Fixed `gate_endpoint` attribute is not loaded. ([#52](https://github.com/mercari/terraform-provider-spinnaker/pull/52))
 
-### Planned breaking change
+### Breaking change
 * Add prefix `v` from next release([#59](https://github.com/mercari/terraform-provider-spinnaker/pull/59)
 
 ## 0.2.1 (July 27, 2020)


### PR DESCRIPTION
## WHAT

As title.

## WHY

Because it is not planned, it's actually happened.
