### PR TITLE
Fix application name validation with cloudprovider input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## v0.2.3 (Unreleased)
+## v0.2.4 (Unreleased)
 
-## v0.2.2 (Auguest 12, 2020)
+## v0.2.3 (August 14, 2020)
+### Bug fixes
+* Fixed validation errors if the user uses deprecated `application` for `spinnaker_application` resource. [#63](https://github.com/mercari/terraform-provider-spinnaker/pull/63)
+
+## v0.2.2 (August 12, 2020)
 ### Improvements
 * Add `spinnaker_canary_config` resource/data source for defining canary config. ([#55](https://github.com/mercari/terraform-provider-spinnaker/pull/55))
     * Note that this currently supports only Cloud Monitoring.

--- a/spinnaker/api/application.go
+++ b/spinnaker/api/application.go
@@ -56,7 +56,7 @@ func NewCreateApplicationTask(d *schema.ResourceData) (CreateApplicationTask, er
 		cloudProviders := make([]string, len(input))
 		for k, input := range v.([]interface{}) {
 			cloudProvider := input.(string)
-			if err := validateSpinnakerApplicationNameByCloudProvider(d.Get("name").(string), cloudProvider); err != nil {
+			if err := validateSpinnakerApplicationNameByCloudProvider(GetApplicationName(d), cloudProvider); err != nil {
 				return nil, err
 			}
 

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -22,6 +22,7 @@ func resourceSpinnakerApplication() *schema.Resource {
 				Deprecated:    "use `name` instead",
 				Optional:      true,
 				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateSpinnakerApplicationName,
 			},
 			"name": {
 				Description:  "Name of the Application",


### PR DESCRIPTION
## WHAT

As title.

## WHY

When users specify `cloud_provider`, the `name` attribute will be fetched. 
But it should fetch `name` or `application` depending on the users input.
