### PR TITLE
Update codeowner to specify uses by GitHub Account

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,9 @@
-* 19yamashita15@gmail.com
+# This is a CODEOWNERS file to define individuals or teams that are responsible
+# for code in a repository.
+#
+# For more detail about CODEOWNERS, refer to following articles:
+#   - https://help.github.com/articles/about-codeowners/
+#   - https://blog.github.com/2017-07-06-introducing-code-owners/
+
+# The default owner
+* @KeisukeYamashita


### PR DESCRIPTION
## WHAT
I've used GitHub's template and specified my GitHub Account, not by email address.

## WHY
Better readability.
