### PR TITLE
Fix checkout github action fetch depth

### DIFF
--- a/.github/workflows/release-provider.yml
+++ b/.github/workflows/release-provider.yml
@@ -27,6 +27,7 @@ jobs:
         run: go build -v
       - name: Run Test
         run: go test -v ./...
+
   publish:
     name: publish
     needs: test
@@ -34,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:


### PR DESCRIPTION
## WHAT
As title.

## WHY

Because the goreleaser needs all branch, commits to create a proper release note.

See below, it's not containing everything...

![image](https://user-images.githubusercontent.com/23056537/104797790-1af04700-5804-11eb-8f13-a9691fc5baa6.png)


## Ref

* [action/checkout](https://github.com/actions/checkout)
