### PR TITLE
Suppress runAsUser diff if using pipeline permissions

### DIFF
--- a/spinnaker/resource_pipeline.go
+++ b/spinnaker/resource_pipeline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -242,5 +243,12 @@ func editAndEncodePipeline(pipelineMap map[string]interface{}) (encodedPipeline 
 	}
 
 	encodedPipeline = string(editedPipelineBytes)
+
+	// Remove runAsUser key if managed service accounts are being used
+	if strings.Contains(encodedPipeline, "runAsUser") {
+		re := regexp.MustCompile(",\"runAsUser\":\".*@managed-service-account\"")
+		encodedPipeline = re.ReplaceAllString(encodedPipeline, "")
+	}
+
 	return
 }


### PR DESCRIPTION
#115 

I'm unsure if this is the best way to remove the `runAsUser` key during the `old` and `new` pipeline comparison, but I found it difficult to remove a key nested under the root keys in the decoded `pipelineMap`. Therfore, I used regexp to remove the `runAsUser` key after the edited pipeline is encoded. 